### PR TITLE
Updated example .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ NEXTAUTH_URL=http://app.localhost:3000
 
 ## PRODUCTION & DEVELOPMENT VARIABLES
 
-# Postgres database URL for Prisma
+# MySQL database URL for Prisma
 DATABASE_URL="mysql://root@127.0.0.1:3309/platforms"
 SHADOW_DATABASE_URL="mysql://root@127.0.0.1:3310/platforms"
 
@@ -14,7 +14,7 @@ TWITTER_ID=
 TWITTER_SECRET=
 TWITTER_AUTH_TOKEN=
 
-# Secret key (generate one here: https://www.uuidgenerator.net/)
+# Secret key (generate one here: https://generate-secret.vercel.app/32)
 SECRET=
 
 AUTH_BEARER_TOKEN=


### PR DESCRIPTION
A few minor tweaks to the `.env.example` file:
 - Updated `DATABASE_URL` comment to recommend the correct database type
 - Changed recommend secret key URL to [generate-secret.vercel.app](https://generate-secret.vercel.app/32) ([sandrinodimattia/generate-secret](https://github.com/sandrinodimattia/generate-secret)) as, while not exactly [what is recommended by NextAuth.js](https://next-auth.js.org/configuration/options#secret) (Uses [`hex`](https://github.com/sandrinodimattia/generate-secret/blob/master/api/%5Blength%5D.js#L17) rather than `base64`), it's better than using a UUID.