### PR TITLE
Upgrade NextAuth.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "dependencies": {
         "@headlessui/react": "^1.4.2",
-        "@next-auth/prisma-adapter": "^0.5.2-next.19",
-        "@prisma/client": "^3.5.0",
+        "@next-auth/prisma-adapter": "^1.0.1",
+        "@prisma/client": "^3.8.1",
         "@tailwindcss/forms": "^0.3.4",
         "@tailwindcss/line-clamp": "^0.3.1",
         "@tailwindcss/typography": "^0.4.1",
@@ -20,7 +20,7 @@
         "gray-matter": "^4.0.3",
         "js-cookie": "^3.0.1",
         "next": "^12.0.8",
-        "next-auth": "^4.0.0-beta.7",
+        "next-auth": "^4.1.2",
         "next-mdx-remote": "^3.0.8",
         "next-plausible": "^3.1.4",
         "plaiceholder": "^2.2.0",
@@ -41,6 +41,7 @@
       "devDependencies": {
         "autoprefixer": "^10.4.0",
         "postcss": "^8.3.11",
+        "prisma": "^3.8.1",
         "tailwindcss": "^2.2.19"
       }
     },
@@ -568,9 +569,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -894,12 +895,12 @@
       }
     },
     "node_modules/@next-auth/prisma-adapter": {
-      "version": "0.5.2-next.19",
-      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-0.5.2-next.19.tgz",
-      "integrity": "sha512-146DWE4PEbgVKF6W0CjJSxeP2rrw2T2s8zX1GQzbQsMK8trRSzheURJRphCn6ZGhVSpHJhU4NZe7F0kwRL5lwQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.1.tgz",
+      "integrity": "sha512-oZ1yDs5pSz19JvyYkIuf52CHpCc79ND/VYl3sX8Cwy3TaTfGgZWHRJfdcj3ordFNKIPxlV2qBYIX2UjgmSyTqQ==",
       "peerDependencies": {
-        "@prisma/client": ">=2.26.0",
-        "next-auth": ">4 || 4.0.0-beta.1 - 4.0.0-beta.x"
+        "@prisma/client": ">=2.26.0 || >=3",
+        "next-auth": "^4.0.1"
       }
     },
     "node_modules/@next/env": {
@@ -1127,12 +1128,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.5.0.tgz",
-      "integrity": "sha512-LuaaisknLe9CCfJ1Rtqe9b9knvPgEEcC77OMmWdo3fSanxl5oTDxcH3IIhpULQQlJfZvDcaEXuXNU4dsNF+q1w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.1.tgz",
+      "integrity": "sha512-NxD1Xbkx1eT1mxSwo1RwZe665mqBETs0VxohuwNfFIxMqcp0g6d4TgugPxwZ4Jb4e5wCu8mQ9quMedhNWIWcZQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
       },
       "engines": {
         "node": ">=12.6"
@@ -1146,10 +1147,17 @@
         }
       }
     },
+    "node_modules/@prisma/engines": {
+      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
+      "integrity": "sha512-bHYubuItSN/DGYo36aDu7xJiJmK52JOSHs4MK+KbceAtwS20BCWadRgtpQ3iZ2EXfN/B1T0iCXlNraaNwnpU2w==",
+      "devOptional": true,
+      "hasInstallScript": true
+    },
     "node_modules/@prisma/engines-version": {
-      "version": "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e.tgz",
-      "integrity": "sha512-X16YmBmj7Omso4ZbkNBe6gPYlNcnwZMUPtXsguCkn+KoMqm3DJD9M4X31gx0Gf13Q44dY3SKPJZUk44/XUj/WA=="
+      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
+      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
     },
     "node_modules/@tailwindcss/forms": {
       "version": "0.3.4",
@@ -2709,9 +2717,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.3.7.tgz",
-      "integrity": "sha512-S7Xfsy8nN9Iw/AZxk+ZxEbd5ImIwJPM0TfAo8zI8FF+3lidQ2yiK4dqzsaPKSbZD0woNVSY0KCql6rlKc5V7ug==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.3.8.tgz",
+      "integrity": "sha512-dFiqN5FPLNWa/v+J3ShFjV/9sRGickxMbGUbqBrYr+BkrqLOieACaavSi9XmLJXe0Uzd7Cgs1oYtDvDrOyWLgw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3175,23 +3183,27 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.0.0-beta.7.tgz",
-      "integrity": "sha512-bPoLak4MfmgrcLLaf26tEQttKJPBcP3KAtSXSo2xMhoG+PLnP9gwFmqLwFUX+FvVRf/iwuAUZjPRAqRQ9g3GOw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.1.2.tgz",
+      "integrity": "sha512-r5Km0eIDgGad+yhegk6OpulAnf7pyxsIpLec3xYB3PIb7F3bUTsvgWm/n/wAvlT0aAF1xKQWOgqhwPjrjte89g==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/balazsorban44"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/nextauth"
         }
       ],
       "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "@panva/hkdf": "^1.0.0",
+        "@babel/runtime": "^7.16.3",
+        "@panva/hkdf": "^1.0.1",
         "cookie": "^0.4.1",
-        "jose": "^4.1.2",
+        "jose": "^4.3.7",
         "oauth": "^0.9.15",
-        "openid-client": "^5.0.2",
-        "preact": "^10.5.14",
+        "openid-client": "^5.1.0",
+        "preact": "^10.6.3",
         "preact-render-to-string": "^5.1.19",
         "uuid": "^8.3.2"
       },
@@ -3451,11 +3463,11 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.0.2.tgz",
-      "integrity": "sha512-Z3fuzy5S/ohIBonXdTFYAKIjMAf0ycRMW0Rs1cXSH1UBJDB2CJTcVR5u7MPlPui5lA1f+mQ9DktPNEwrYVoY+A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.2.tgz",
+      "integrity": "sha512-AV5wCy011lrZZvzQa4HGhItTb64+D8V50vEtS/HhaFjiM8jDItUyDu4C73nMr6zrlEvgprFdbyGGwkGiQ4ggJg==",
       "dependencies": {
-        "jose": "^4.1.0",
+        "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.1"
@@ -3704,9 +3716,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.0.tgz",
-      "integrity": "sha512-5gpdQkPsfl8ycSQSLSZxSvkifZ9FM4Zqc1OSToSpgygvgmXjcj6Q5jNRt86ote8dn0RkdOaKv9UAZTU7a6wP+g==",
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
+      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -3771,6 +3783,23 @@
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.8.1.tgz",
+      "integrity": "sha512-Q8zHwS9m70TaD7qI8u+8hTAmiTpK+IpvRYF3Rgb/OeWGQJOMgZCFFvNCiSfoLEQ95wilK7ctW3KOpc9AuYnRUA==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+      },
+      "bin": {
+        "prisma": "build/index.js",
+        "prisma2": "build/index.js"
+      },
+      "engines": {
+        "node": ">=12.6"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5632,9 +5661,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -5876,9 +5905,9 @@
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
     "@next-auth/prisma-adapter": {
-      "version": "0.5.2-next.19",
-      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-0.5.2-next.19.tgz",
-      "integrity": "sha512-146DWE4PEbgVKF6W0CjJSxeP2rrw2T2s8zX1GQzbQsMK8trRSzheURJRphCn6ZGhVSpHJhU4NZe7F0kwRL5lwQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.1.tgz",
+      "integrity": "sha512-oZ1yDs5pSz19JvyYkIuf52CHpCc79ND/VYl3sX8Cwy3TaTfGgZWHRJfdcj3ordFNKIPxlV2qBYIX2UjgmSyTqQ==",
       "requires": {}
     },
     "@next/env": {
@@ -5987,17 +6016,23 @@
       "integrity": "sha512-mMyQ9vjpuFqePkfe5bZVIf/H3Dmk6wA8Kjxff9RcO4kqzJo+Ek9pGKwZHpeMr7Eku0QhLXMCd7fNCSnEnRMubg=="
     },
     "@prisma/client": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.5.0.tgz",
-      "integrity": "sha512-LuaaisknLe9CCfJ1Rtqe9b9knvPgEEcC77OMmWdo3fSanxl5oTDxcH3IIhpULQQlJfZvDcaEXuXNU4dsNF+q1w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.8.1.tgz",
+      "integrity": "sha512-NxD1Xbkx1eT1mxSwo1RwZe665mqBETs0VxohuwNfFIxMqcp0g6d4TgugPxwZ4Jb4e5wCu8mQ9quMedhNWIWcZQ==",
       "requires": {
-        "@prisma/engines-version": "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e"
+        "@prisma/engines-version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
       }
     },
+    "@prisma/engines": {
+      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
+      "integrity": "sha512-bHYubuItSN/DGYo36aDu7xJiJmK52JOSHs4MK+KbceAtwS20BCWadRgtpQ3iZ2EXfN/B1T0iCXlNraaNwnpU2w==",
+      "devOptional": true
+    },
     "@prisma/engines-version": {
-      "version": "3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.5.0-38.78a5df6def6943431f4c022e1428dbc3e833cf8e.tgz",
-      "integrity": "sha512-X16YmBmj7Omso4ZbkNBe6gPYlNcnwZMUPtXsguCkn+KoMqm3DJD9M4X31gx0Gf13Q44dY3SKPJZUk44/XUj/WA=="
+      "version": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f.tgz",
+      "integrity": "sha512-G2JH6yWt6ixGKmsRmVgaQYahfwMopim0u/XLIZUo2o/mZ5jdu7+BL+2V5lZr7XiG1axhyrpvlyqE/c0OgYSl3g=="
     },
     "@tailwindcss/forms": {
       "version": "0.3.4",
@@ -7146,9 +7181,9 @@
       }
     },
     "jose": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.3.7.tgz",
-      "integrity": "sha512-S7Xfsy8nN9Iw/AZxk+ZxEbd5ImIwJPM0TfAo8zI8FF+3lidQ2yiK4dqzsaPKSbZD0woNVSY0KCql6rlKc5V7ug=="
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.3.8.tgz",
+      "integrity": "sha512-dFiqN5FPLNWa/v+J3ShFjV/9sRGickxMbGUbqBrYr+BkrqLOieACaavSi9XmLJXe0Uzd7Cgs1oYtDvDrOyWLgw=="
     },
     "js-cookie": {
       "version": "3.0.1",
@@ -7486,17 +7521,17 @@
       }
     },
     "next-auth": {
-      "version": "4.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.0.0-beta.7.tgz",
-      "integrity": "sha512-bPoLak4MfmgrcLLaf26tEQttKJPBcP3KAtSXSo2xMhoG+PLnP9gwFmqLwFUX+FvVRf/iwuAUZjPRAqRQ9g3GOw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.1.2.tgz",
+      "integrity": "sha512-r5Km0eIDgGad+yhegk6OpulAnf7pyxsIpLec3xYB3PIb7F3bUTsvgWm/n/wAvlT0aAF1xKQWOgqhwPjrjte89g==",
       "requires": {
-        "@babel/runtime": "^7.15.4",
-        "@panva/hkdf": "^1.0.0",
+        "@babel/runtime": "^7.16.3",
+        "@panva/hkdf": "^1.0.1",
         "cookie": "^0.4.1",
-        "jose": "^4.1.2",
+        "jose": "^4.3.7",
         "oauth": "^0.9.15",
-        "openid-client": "^5.0.2",
-        "preact": "^10.5.14",
+        "openid-client": "^5.1.0",
+        "preact": "^10.6.3",
         "preact-render-to-string": "^5.1.19",
         "uuid": "^8.3.2"
       }
@@ -7657,11 +7692,11 @@
       }
     },
     "openid-client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.0.2.tgz",
-      "integrity": "sha512-Z3fuzy5S/ohIBonXdTFYAKIjMAf0ycRMW0Rs1cXSH1UBJDB2CJTcVR5u7MPlPui5lA1f+mQ9DktPNEwrYVoY+A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.2.tgz",
+      "integrity": "sha512-AV5wCy011lrZZvzQa4HGhItTb64+D8V50vEtS/HhaFjiM8jDItUyDu4C73nMr6zrlEvgprFdbyGGwkGiQ4ggJg==",
       "requires": {
-        "jose": "^4.1.0",
+        "jose": "^4.1.4",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.0.1",
         "oidc-token-hash": "^5.0.1"
@@ -7819,9 +7854,9 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "preact": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.0.tgz",
-      "integrity": "sha512-5gpdQkPsfl8ycSQSLSZxSvkifZ9FM4Zqc1OSToSpgygvgmXjcj6Q5jNRt86ote8dn0RkdOaKv9UAZTU7a6wP+g=="
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.6.4.tgz",
+      "integrity": "sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ=="
     },
     "preact-render-to-string": {
       "version": "5.1.19",
@@ -7865,6 +7900,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+    },
+    "prisma": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.8.1.tgz",
+      "integrity": "sha512-Q8zHwS9m70TaD7qI8u+8hTAmiTpK+IpvRYF3Rgb/OeWGQJOMgZCFFvNCiSfoLEQ95wilK7ctW3KOpc9AuYnRUA==",
+      "devOptional": true,
+      "requires": {
+        "@prisma/engines": "3.8.0-43.34df67547cf5598f5a6cd3eb45f14ee70c3fb86f"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
   "private": true,
   "scripts": {
-    "predev": "npx prisma generate",
+    "predev": "prisma generate",
     "dev": "next dev",
-    "prebuild": "npx prisma generate",
+    "prebuild": "prisma generate",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prisma:migrate": "npx prisma migrate deploy"
+    "prisma:migrate": "prisma migrate deploy"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.2",
-    "@next-auth/prisma-adapter": "^0.5.2-next.19",
-    "@prisma/client": "^3.5.0",
+    "@next-auth/prisma-adapter": "^1.0.1",
+    "@prisma/client": "^3.8.1",
     "@tailwindcss/forms": "^0.3.4",
     "@tailwindcss/line-clamp": "^0.3.1",
     "@tailwindcss/typography": "^0.4.1",
@@ -25,7 +25,7 @@
     "gray-matter": "^4.0.3",
     "js-cookie": "^3.0.1",
     "next": "^12.0.8",
-    "next-auth": "^4.0.0-beta.7",
+    "next-auth": "^4.1.2",
     "next-mdx-remote": "^3.0.8",
     "next-plausible": "^3.1.4",
     "plaiceholder": "^2.2.0",
@@ -46,6 +46,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.0",
     "postcss": "^8.3.11",
+    "prisma": "^3.8.1",
     "tailwindcss": "^2.2.19"
   }
 }


### PR DESCRIPTION
When first trying to set up the project I ran into a `getUserByAccount is not a function` error. Seems an upgrade to `next-auth` was required.

This PR does 2 things:
 - Adds `prisma` as a dev dependency (Saves calling `npx` every time)
 - Upgrades `next-auth`, `@next-auth/prisma-adapter`,  `@prisma/client` to their latest versions (Fixes the error mentioned above)