### PR TITLE
fix: remove SHADOW_DATABASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ NEXTAUTH_URL=http://app.localhost:3000
 
 # MySQL database URL for Prisma
 DATABASE_URL="mysql://root@127.0.0.1:3309/platforms"
-SHADOW_DATABASE_URL="mysql://root@127.0.0.1:3310/platforms"
 
 # Github OAuth https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
 GITHUB_ID=

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,7 +4,6 @@
 datasource db {
   provider             = "mysql"
   url                  = env("DATABASE_URL")
-  shadowDatabaseUrl    = env("SHADOW_DATABASE_URL")
   referentialIntegrity = "prisma"
 }
 


### PR DESCRIPTION
We no longer need  `SHADOW_DATABASE_URL` anymore when using `npx prisma db push`