### PR TITLE
add comment for the different domain.

### DIFF
--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -13,7 +13,7 @@ export default function middleware(req) {
   const currentHost =
     process.env.NODE_ENV === "production" && process.env.VERCEL === "1"
       ? hostname
-          .replace(`.vercel.pub`, "")
+          .replace(`.vercel.pub`, "") // you have to replace ".vercel.pub" with your own domain if you deploy this example under your domain.
           .replace(`.platformize.vercel.app`, "") // you can use wildcard subdomains on .vercel.app links that are associated with your Vercel team slug
       : // in this case, our team slug is "platformize", thus *.platformize.vercel.app works
         hostname.replace(`.localhost:3000`, "");


### PR DESCRIPTION
Related the issue #60, I suggest adding some comments on _middleware.js not to miss modifying the domain when people use this example under their own domains.

It is hard to recognize where to modify at first glance.