### PR TITLE
Redirect to URL object instead of relative URL

### DIFF
--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -29,7 +29,8 @@ export default function middleware(req) {
         (req.cookies["next-auth.session-token"] ||
           req.cookies["__Secure-next-auth.session-token"])
       ) {
-        return NextResponse.redirect("/");
+        url.pathname = "/";
+        return NextResponse.redirect(url);
       }
       url.pathname = `/app${pathname}`;
       return NextResponse.rewrite(url);


### PR DESCRIPTION
This fixes #48 and #71.

Why this is required: https://nextjs.org/docs/messages/middleware-relative-urls

Of course everything is up for discussion! Hope this helps and thanks for this starter.