### PR TITLE
add pathname to /home url when rewritting

### DIFF
--- a/pages/_middleware.ts
+++ b/pages/_middleware.ts
@@ -56,7 +56,7 @@ export default function middleware(req: NextRequest) {
       hostname === "localhost:3000" ||
       hostname === "platformize.vercel.app"
     ) {
-      url.pathname = `/home`;
+      url.pathname = `/home${pathname}`;
       return NextResponse.rewrite(url);
     }
 


### PR DESCRIPTION
Hello, guys! I just discover this template and was playing with it today. Really cool stuff right here. 🤍

I noticed something strange when trying to go `localhost:3000`. The middleware was always rewriting to `/home` without its corresponding `pathname`, hence always rendering `index.tsx` no matter what route you were trying to visit.

So I just added `${pathname}` in front of `/home` in the url.pathname when visiting `localhost:3000/*`