### PR TITLE
Only ignore exact folder matches

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,7 @@ export const config = {
      * 4. /examples (inside /public)
      * 5. all root files inside /public (e.g. /favicon.ico)
      */
-    "/((?!api|_next|fonts|examples|[\\w-]+\\.\\w+).*)",
+    '/((?!api/|_next/|fonts/|examples/|[\\w-]+\\.\\w+).*)',
   ],
 };
 


### PR DESCRIPTION
The current regex ignores all folders that start with `/api` rather than _only_ skipping `/api/`.

Mintlify was using this middleware example and we found pages hosted at `/api-components/` and `/api-reference/` were 404ing because this middleware was preventing us from serving them.