### PR TITLE
Get the query params of the request

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,9 @@ export default async function middleware(req: NextRequest) {
   // Get the pathname of the request (e.g. /, /about, /blog/first-post)
   const path = url.pathname;
 
+  // Get the query params of the request (e.g. ?name=nextjs)
+  const query = url.search;
+
   // Only for demo purposes - remove this if you want to use your root domain as the landing page
   if (hostname === "vercel.pub" || hostname === "platforms.vercel.app") {
     return NextResponse.redirect("https://demo.vercel.pub");
@@ -61,6 +64,6 @@ export default async function middleware(req: NextRequest) {
 
   // rewrite everything else to `/_sites/[site] dynamic route
   return NextResponse.rewrite(
-    new URL(`/_sites/${currentHost}${path}`, req.url)
+    new URL(`/_sites/${currentHost}${path}${query}`, req.url)
   );
 }


### PR DESCRIPTION
Our use of Vercel Platforms requires that we can access query parameters after the middleware redirect which didn't work until I added the following code:

```
const fullPath = `/${currentSite}${path}${query}`;
console.log('fullPath', fullPath);

// Without Query Params
// fullPath /my-site/test

// With Query Params
// fullPath /my-site/test?q=1
```

