### PR TITLE
Chore: collapse imports from the same library into a single statement

### DIFF
--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -12,6 +12,8 @@ import {
   Menu,
   Newspaper,
   Settings,
+  FileCode,
+  Github,
 } from "lucide-react";
 import {
   useParams,
@@ -21,7 +23,6 @@ import {
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { getSiteFromPostId } from "@/lib/actions";
 import Image from "next/image";
-import { FileCode, Github } from "lucide-react";
 
 const externalLinks = [
   {


### PR DESCRIPTION
I've started to use the platform template for a project and have been loving it as a starting point and as a way to learn about next 13.

I noticed in the `components/nav.tsx` file the application is importing icons twice from `lucide-react`. This small PR removes the second import and moves the imported icons to the first import statement. 

First time contributing so please let me know if I need to do or should have done anything differently. Thank you!