### PR TITLE
fix: incorrect params in /app/sites

### DIFF
--- a/app/app/(dashboard)/sites/page.tsx
+++ b/app/app/(dashboard)/sites/page.tsx
@@ -4,7 +4,7 @@ import PlacholderCard from "@/components/placeholder-card";
 import CreateSiteButton from "@/components/create-site-button";
 import CreateSiteModal from "@/components/modal/create-site";
 
-export default function AllSites({ params }: { params: { id: string } }) {
+export default function AllSites({ params }: { params: { limit?: number } }) {
   return (
     <div className="flex max-w-screen-xl flex-col space-y-12 p-8">
       <div className="flex flex-col space-y-6">
@@ -26,7 +26,7 @@ export default function AllSites({ params }: { params: { id: string } }) {
           }
         >
           {/* @ts-expect-error Server Component */}
-          <Sites siteId={params.id} />
+          <Sites limit={params?.limit} />
         </Suspense>
       </div>
     </div>


### PR DESCRIPTION
Hi,

This PR fixe an incorrect param in the `/app/sites` page (**id** vs **limit**).

The `<Sites ... />` component: 
https://github.com/vercel/platforms/blob/7ded19df0220acad5ae4280f9ebc139bcb1fa64c/components/sites.tsx#L7

The incorrect param in page: 
https://github.com/vercel/platforms/blob/7ded19df0220acad5ae4280f9ebc139bcb1fa64c/app/app/(dashboard)/sites/page.tsx#L7

And fix this prop component:
https://github.com/vercel/platforms/blob/7ded19df0220acad5ae4280f9ebc139bcb1fa64c/app/app/(dashboard)/sites/page.tsx#L29