### PR TITLE
Support https on localhost

### DIFF
--- a/.dev/README.md
+++ b/.dev/README.md
@@ -1,0 +1,22 @@
+## Accessing Next.js dev server using HTTPS
+
+Inspired by https://www.makeswift.com/blog/accessing-your-local-nextjs-dev-server-using-https
+
+This is a workaround for the issue that Next.js dev server doesn't support HTTPS.
+It requires mkcert to be installed on your machine.
+Read above blog post for more details.
+
+
+### Run the following commands to start the dev server:
+```bash
+brew instal mkcert
+cd .dev/
+mkcert -install
+mkcert localhost
+pnpm dev
+```
+
+Visit https://localhost:3000 in your browser.  
+You should see a warning about the certificate not being trusted.  
+This is expected.  
+Click on "Advanced" and then "Proceed to localhost (unsafe)".

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .vscode
 **.git
 .vercel
+/*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .vscode
 **.git
 .vercel
-/*.pem
+/.dev/*.pem

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "autoprefixer": "^10.4.14",
     "eslint": "8.31.0",
     "eslint-config-next": "^13.4.9",
+    "local-ssl-proxy": "^2.0.5",
     "postcss": "^8.4.25",
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "dev": "pnpm exec -- sh -c \"prisma generate & pnpm next:dev & pnpm local-ssl-proxy\"",
+    "dev": "pnpm exec -- sh -c \"prisma generate & pnpm next:dev & pnpm proxy\"",
     "next:dev": "next dev -p 3001",
-    "local-ssl-proxy": "npx local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3000 --target 3001",
+    "proxy": "npx local-ssl-proxy --key .dev/localhost-key.pem --cert .dev/localhost.pem --source 3000 --target 3001",
     "build": "prisma generate && prisma db push && next build",
     "format:write": "prettier --write \"**/*.{css,js,json,jsx,ts,tsx}\"",
     "format": "prettier \"**/*.{css,js,json,jsx,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "scripts": {
-    "dev": "prisma generate && next dev",
+    "dev": "pnpm exec -- sh -c \"prisma generate & pnpm next:dev & pnpm local-ssl-proxy\"",
+    "next:dev": "next dev -p 3001",
+    "local-ssl-proxy": "npx local-ssl-proxy --key localhost-key.pem --cert localhost.pem --source 3000 --target 3001",
     "build": "prisma generate && prisma db push && next build",
     "format:write": "prettier --write \"**/*.{css,js,json,jsx,ts,tsx}\"",
     "format": "prettier \"**/*.{css,js,json,jsx,ts,tsx}\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ devDependencies:
   eslint-config-next:
     specifier: ^13.4.9
     version: 13.4.9(eslint@8.31.0)(typescript@5.1.6)
+  local-ssl-proxy:
+    specifier: ^2.0.5
+    version: 2.0.5
   postcss:
     specifier: ^8.4.25
     version: 8.4.25
@@ -2355,6 +2358,11 @@ packages:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  /ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2748,6 +2756,11 @@ packages:
   /comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: false
+
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3739,7 +3752,6 @@ packages:
 
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
-    dev: false
 
   /eventsource-parser@0.1.0:
     resolution: {integrity: sha512-M9QjFtEIkwytUarnx113HGmgtk52LSn3jNAtnWKi3V+b9rqSfQeVdLsaD5AG/O4IrGQwmAAHBIsqbmURPTd2rA==}
@@ -3872,6 +3884,16 @@ packages:
     dependencies:
       tabbable: 6.2.0
     dev: false
+
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: true
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -4182,6 +4204,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.2
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -4720,6 +4753,17 @@ packages:
   /linkifyjs@4.1.1:
     resolution: {integrity: sha512-zFN/CTVmbcVef+WaDXT63dNzzkfRBKT1j464NJQkV7iSgJU0sLBus9W0HBwnXK13/hf168pbrx/V/bjEHOXNHA==}
     dev: false
+
+  /local-ssl-proxy@2.0.5:
+    resolution: {integrity: sha512-/oWxo8IX12HTVNWza+Ui1HNz7TfrNsVyD0+ZSyf5UZocJXdR70wfNb/xHgNfEPFyjgbsaRFdqFdfxg2d11aANQ==}
+    hasBin: true
+    dependencies:
+      ansi-colors: 4.1.3
+      commander: 10.0.1
+      http-proxy: 1.18.1
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -6487,7 +6531,6 @@ packages:
 
   /requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}


### PR DESCRIPTION
Allow developers to test local pages that require authentication.
Added a readme file with instructions for developers to set up their local environment.

![Screenshot 2023-09-02 at 11 45 26 PM](https://github.com/vercel/platforms/assets/12414043/08e27b33-2534-450c-9d14-0d312cc9cea0)
