### PR TITLE
fix: issue that causes root home page to 404 on vercel

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -51,7 +51,7 @@ export default async function middleware(req: NextRequest) {
     hostname === "localhost:3000" ||
     hostname === process.env.NEXT_PUBLIC_ROOT_DOMAIN
   ) {
-    return NextResponse.rewrite(new URL(`/home${path}`, req.url));
+    return NextResponse.rewrite(new URL(`/home${path === "/" ? "" : path}`, req.url));
   }
 
   // rewrite everything else to `/[domain]/[path] dynamic route


### PR DESCRIPTION
Trying to access the root home page (ex. ``https://domain.com``) redirected to the default 404 page on Vercel deployments while working perfectly fine locally.

Issue is that the middleware redirects to ``https://domain.com/`` (slash included at the end), which seems to cause a 404. 