### PR TITLE
Fix analytics Top Pages rendering bug

### DIFF
--- a/components/analytics.tsx
+++ b/components/analytics.tsx
@@ -40,7 +40,7 @@ const chartdata = [
 ];
 
 const pages = [
-  { name: "/platforms-starter-kit", value: "1,230" },
+  { name: "/platforms-starter-kit", value: 1230 },
   { name: "/vercel-is-now-bercel", value: 751 },
   { name: "/nextjs-conf", value: 471 },
   { name: "/150m-series-d", value: 280 },


### PR DESCRIPTION
fixes the rendering of the Top Pages section in the analytics page, renders as a full length entry for all items before, now properly lengthens the bars.

![image](https://github.com/vercel/platforms/assets/147033096/6aca3a8a-bde8-40a0-bfb7-a10ead22020b)
![image](https://github.com/vercel/platforms/assets/147033096/509c6ecb-0a89-4954-a5e0-3ab9588dae46)
