### PR TITLE
Added @db.Text to prisma schema account model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,13 +34,13 @@ model Account {
   type                     String
   provider                 String
   providerAccountId        String
-  refresh_token            String?
+  refresh_token            String? @db.Text
   refresh_token_expires_in Int?
-  access_token             String?
+  access_token             String? @db.Text
   expires_at               Int?
   token_type               String?
   scope                    String?
-  id_token                 String?
+  id_token                 String? @db.Text
   session_state            String?
   oauth_token_secret       String?
   oauth_token              String?


### PR DESCRIPTION
Added `@db.Text` to prisma schema Account model's `refresh_token`, `access_token`, and `id_token` to support NextAuth's Google provider callback's account creation. 

Without `@db.Text`, platform skips the creation of a record in the accounts table for the user resulting `OAuthAccountNotLinked` error.