### PR TITLE
fix: editor color doesn't change in dark theme (fixes #315)

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
+import { ThemeProvider, useTheme } from "next-themes";
 import { Toaster } from "sonner";
 import { ModalProvider } from "@/components/modal/provider";
+
+const ToasterProvider = () => {
+  const { theme } = useTheme() as {
+    theme: "light" | "dark" | "system"
+  };
+  return <Toaster theme={theme} />
+};
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <Toaster className="dark:hidden" />
-      <Toaster theme="dark" className="hidden dark:block" />
-      <ModalProvider>{children}</ModalProvider>
+      <ThemeProvider>
+        <ToasterProvider />
+        <ModalProvider>{children}</ModalProvider>
+      </ThemeProvider>
     </SessionProvider>
   );
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "next": "14.0.2",
     "next-auth": "4.24.5",
     "next-mdx-remote": "^4.4.1",
+    "next-themes": "^0.2.1",
     "novel": "^0.1.22",
     "openai-edge": "^1.2.2",
     "react": "^18.2.0",


### PR DESCRIPTION
This PR uses the' next-themes' package to fix the editor color in a dark theme.
I got the idea from [novel's preview page](https://github.com/steven-tey/novel/blob/main/apps/web/app/providers.tsx#L28).

The point is to have `color-scheme: dark;` CSS code. This changes the default color theme in the whole site, which the novel package follows.

You might achieve the same thing by creating CSS for each element but that's a pain in the arse so I did this instead.