### PR TITLE
Update .env.example file with Vercel deployment suffix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ NEXTAUTH_URL=http://app.localhost:3000
 # Change this to your own domain
 NEXT_PUBLIC_ROOT_DOMAIN=vercel.pub
 
+# Suffix for Vercel preview deployment URLs
+NEXT_PUBLIC_VERCEL_DEPLOYMENT_SUFFIX=
+
 # PostgreSQL database URL – get one here: https://vercel.com/docs/storage/vercel-postgres/quickstart
 POSTGRES_PRISMA_URL=
 POSTGRES_URL_NON_POOLING=


### PR DESCRIPTION
An environment variable is missing, which is in the middleware, but in the .env.example it does not appear.

```
  if (
    hostname.includes("---") &&
    hostname.endsWith(`.${process.env.NEXT_PUBLIC_VERCEL_DEPLOYMENT_SUFFIX}`)
  ) {
    hostname = `${hostname.split("---")[0]}.${
      process.env.NEXT_PUBLIC_ROOT_DOMAIN
    }`;
  }
```