### PR TITLE
docs: add tanstack start version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A production-ready example of a multi-tenant application built with Next.js 15, featuring custom subdomains for each tenant.
 
+[TanStack Start version](https://github.com/xiaoyu2er/tanstack-platforms)
+
 ## Features
 
 - ✅ Custom subdomain routing with Next.js middleware


### PR DESCRIPTION
https://github.com/xiaoyu2er/tanstack-platforms is a fork of https://github.com/vercel/platforms
and it was built with tanstack start. 