### PR TITLE
Fix middleware to handle search parameters in URL rewrite

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -52,7 +52,9 @@ export async function middleware(request: NextRequest) {
 
     // For the root path on a subdomain, rewrite to the subdomain page
     if (pathname === '/') {
-      return NextResponse.rewrite(new URL(`/s/${subdomain}`, request.url));
+      const url = request.nextUrl.clone();
+      url.pathname = `/s/${subdomain}`;
+      return NextResponse.rewrite(url);
     }
   }
 
@@ -68,6 +70,6 @@ export const config = {
      * 2. /_next (Next.js internals)
      * 3. all root files inside /public (e.g. /favicon.ico)
      */
-    '/((?!api|_next|[\\w-]+\\.\\w+).*)'
-  ]
+    '/((?!api|_next|[\\w-]+\\.\\w+).*)',
+  ],
 };


### PR DESCRIPTION
I have been building on top of the Vercel multi-tenant example in my own project and encountered an issue when attempting to access search parameters in the URL. This is a common scenario for many applications, as users often pass important data through query parameters.

The current middleware implementation rewrites the URL for the root path but does not retain any search parameters, leading to a loss of critical data. To ensure that search parameters are preserved, I propose a modification to the rewrite logic. This change is essential for maintaining the integrity of user input and improving the overall user experience in multi-tenant applications. 