### PR TITLE
fix: block access to subdomain pages from the root domain

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -56,6 +56,11 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // Block access to the subdomain pages from the root domain
+  if (pathname.startsWith('/s/')) {
+    return NextResponse.rewrite(new URL('/404', request.url))
+  }
+
   // On the root domain, allow normal access
   return NextResponse.next();
 }


### PR DESCRIPTION
This sample allows subdomains to be accessed from the root domain:

`https://hello.vercel.pub` could be accessed by going to `https://vercel.pub/s/hello`

Adding in

```typescript
// Block access to the subdomain pages from the root domain
if (pathname.startsWith('/s/')) {
  return NextResponse.rewrite(new URL('/404', request.url))
}
```

would fix it.

### `middleware.ts`

```typescript
export async function middleware(request: NextRequest) {
  const { pathname } = request.nextUrl;
  const subdomain = extractSubdomain(request);

  if (subdomain) {
    // Block access to admin page from subdomains
    if (pathname.startsWith('/admin')) {
      return NextResponse.redirect(new URL('/', request.url));
    }

    // For the root path on a subdomain, rewrite to the subdomain page
    if (pathname === '/') {
      return NextResponse.rewrite(new URL(`/s/${subdomain}`, request.url));
    }
  }

  // Block access to the subdomain pages from the root domain
  if (pathname.startsWith('/s/')) {
    return NextResponse.rewrite(new URL('/404', request.url))
  }

  // On the root domain, allow normal access
  return NextResponse.next();
}
```