### PR TITLE
Security and QoL fixes for middleware.ts, to be a better example.

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -16,7 +16,10 @@ function extractSubdomain(request: NextRequest): string | null {
 
     // Fallback to host header approach
     if (hostname.includes('.localhost')) {
-      return hostname.split('.')[0];
+      return hostname
+        .split('.')
+        .filter((e) => e !== 'localhost')
+        .join('.')
     }
 
     return null;
@@ -41,7 +44,7 @@ function extractSubdomain(request: NextRequest): string | null {
 }
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, search } = request.nextUrl;
   const subdomain = extractSubdomain(request);
 
   if (subdomain) {
@@ -50,10 +53,13 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(new URL('/', request.url));
     }
 
-    // For the root path on a subdomain, rewrite to the subdomain page
-    if (pathname === '/') {
-      return NextResponse.rewrite(new URL(`/s/${subdomain}`, request.url));
-    }
+    // Rewrite to the subdomain page
+    return NextResponse.rewrite(new URL(`/s/${subdomain}${pathname}${search}`, request.url))
+  }
+
+  // Catch forced browsing of /s/[domain]
+  if (pathname.startsWith('/s/')) {
+    return NextResponse.redirect(new URL('/', request.url))
   }
 
   // On the root domain, allow normal access


### PR DESCRIPTION
fix: subdomain match for localhost gives all of the domain excluding .localhost.
fix: extract pathname and search parameters and apply to rewritten URLs - fixes #460 and and fixes #462
fix: block forced browsing of tenants - fixes #456 