### PR TITLE
feat: prefill subdomain from requested hostname

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -5,9 +5,10 @@ import { isValidIcon } from '@/lib/subdomains';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { rootDomain, protocol } from '@/lib/utils';
+import { CreateState } from './subdomain-form';
 
 export async function createSubdomainAction(
-  prevState: any,
+  prevState: CreateState,
   formData: FormData
 ) {
   const subdomain = formData.get('subdomain') as string;
@@ -59,7 +60,7 @@ export async function createSubdomainAction(
 }
 
 export async function deleteSubdomainAction(
-  prevState: any,
+  prevState: CreateState,
   formData: FormData
 ) {
   const subdomain = formData.get('subdomain');

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -44,7 +44,7 @@ export default function NotFound() {
         </p>
         <div className="mt-6">
           <Link
-            href={`${protocol}://${rootDomain}`}
+            href={`${protocol}://${rootDomain}?subdomain=${subdomain}`}
             className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
           >
             {subdomain ? `Create ${subdomain}` : `Go to ${rootDomain}`}

--- a/app/subdomain-form.tsx
+++ b/app/subdomain-form.tsx
@@ -22,8 +22,9 @@ import {
 } from '@/components/ui/emoji-picker';
 import { createSubdomainAction } from '@/app/actions';
 import { rootDomain } from '@/lib/utils';
+import { useSearchParams } from 'next/navigation';
 
-type CreateState = {
+export type CreateState = {
   error?: string;
   success?: boolean;
   subdomain?: string;
@@ -132,9 +133,12 @@ export function SubdomainForm() {
     {}
   );
 
+  const searchParams = useSearchParams();
+  const subdomain = state?.subdomain ?? searchParams.get('subdomain') ?? '';
+
   return (
     <form action={action} className="space-y-4">
-      <SubdomainInput defaultValue={state?.subdomain} />
+      <SubdomainInput defaultValue={subdomain} />
 
       <IconPicker icon={icon} setIcon={setIcon} defaultValue={state?.icon} />
 


### PR DESCRIPTION
- When a user visits a non-existent subdomain, we already know their intent
- This change passes the subdomain to the creation flow
- Improves UX by removing duplicate typing
- No breaking changes

Before:
![subdomain-before](https://github.com/user-attachments/assets/6c40656c-8648-4f2d-a68f-59a08bb727f9)

After:
![subdomain-after](https://github.com/user-attachments/assets/e3ae207e-b687-459d-a87f-6537ac88e0d6)
